### PR TITLE
Add text to cards in edit window

### DIFF
--- a/EditStack.py
+++ b/EditStack.py
@@ -59,7 +59,37 @@ class EditStack(QWidget):
 
         #rest of GUI added here
 
-        #TODO: add edit stack code
+        row = QHBoxLayout()
+
+        #TODO: list of cards
+
+        row.addStretch(2)
+
+        editSplit = QVBoxLayout()
+
+        editArea = QGroupBox('Edit Card')
+
+        editForm = QFormLayout()
+
+        editForm.addRow(QLabel('Front text'), QTextEdit())
+        editForm.addRow(QLabel('Back text'), QTextEdit())
+
+        editArea.setLayout(editForm)
+
+        editSplit.addWidget(editArea)
+
+        editSplit.addStretch(1)
+
+        #TODO: add drag/drop components (maybe)
+        #could be something else
+
+        row.addLayout(editSplit)
+
+        row.addStretch(1)
+
+        self.fullLayout.addLayout(row)
+
+        self.fullLayout.addStretch(1)
 
         self.setLayout(self.fullLayout)
 

--- a/EditStack.py
+++ b/EditStack.py
@@ -92,11 +92,11 @@ class EditStack(QWidget):
 
         editSplit.addWidget(editArea)
 
-        save_dont = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Discard)
-        save_dont.accepted.connect(self.save)
-        save_dont.rejected.connect(self.reject)
+        saveChangesDialog = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Discard)
+        saveChangesDialog.accepted.connect(self.save)
+        saveChangesDialog.rejected.connect(self.reject)
 
-        editSplit.addWidget(save_dont)
+        editSplit.addWidget(saveChangesDialog)
 
         editSplit.addStretch(1)
 

--- a/EditStack.py
+++ b/EditStack.py
@@ -22,11 +22,15 @@ class EditStack(QWidget):
 
     @pyqtSlot()
     def backToMainMenu(self):
+        if not self.checkSaved():
+            return
         self.hide()
         openMainMenu(self)
 
     @pyqtSlot()
     def enterStudyMode(self):
+        if not self.checkSaved():
+            return
         self.hide()
         openViewWindow(self)
 
@@ -69,6 +73,9 @@ class EditStack(QWidget):
 
         editArea = QGroupBox('Edit Card')
 
+        #this could potentially be dynamically generated
+        #it would be challenging to handle the updates
+
         editForm = QFormLayout()
 
         self.frontText = QTextEdit()
@@ -78,6 +85,8 @@ class EditStack(QWidget):
         self.backText = QTextEdit()
         self.backText.textChanged.connect(self.makeChanges)
         editForm.addRow(QLabel('Back text'), self.backText)
+
+        #TODO: file browser for selecting an image
 
         editArea.setLayout(editForm)
 
@@ -119,14 +128,14 @@ class EditStack(QWidget):
     #sets the unsavedChanges flag
     #a method is needed because assignment isn't allowed inside of lambda
     #this method is called whenever the textboxes are modified
+    @pyqtSlot()
     def makeChanges(self):
         self.unsavedChanges = True
 
-    #the MainMenu needs to be opened on close
-    #edits need to be checked to unsure nothing is unsaved
-    def closeEvent(self, event):
-        close = True
-
+    #check if the content has been saved
+    #and save it if the user choses to
+    #returns whether it is OK to exit
+    def checkSaved(self):
         if self.unsavedChanges:
             reply = QMessageBox.question(self, 'Unsaved changes',
                 'Would you like to save your changes?',
@@ -135,8 +144,19 @@ class EditStack(QWidget):
             if reply == QMessageBox.Save:
                 self.save()
             elif reply == QMessageBox.Cancel:
-                event.ignore()
-                return
+                return False
+
+        return True
+
+
+    #the MainMenu needs to be opened on close
+    #edits need to be checked to unsure nothing is unsaved
+    def closeEvent(self, event):
+        close = True
+
+        if not self.checkSaved():
+            event.ignore()
+            return
 
         openMainMenu(self)
         event.accept()

--- a/EditStack.py
+++ b/EditStack.py
@@ -71,12 +71,23 @@ class EditStack(QWidget):
 
         editForm = QFormLayout()
 
-        editForm.addRow(QLabel('Front text'), QTextEdit())
-        editForm.addRow(QLabel('Back text'), QTextEdit())
+        self.frontText = QTextEdit()
+        self.frontText.textChanged.connect(self.makeChanges)
+        editForm.addRow(QLabel('Front text'), self.frontText)
+
+        self.backText = QTextEdit()
+        self.backText.textChanged.connect(self.makeChanges)
+        editForm.addRow(QLabel('Back text'), self.backText)
 
         editArea.setLayout(editForm)
 
         editSplit.addWidget(editArea)
+
+        save_dont = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Discard)
+        save_dont.accepted.connect(self.save)
+        save_dont.rejected.connect(self.reject)
+
+        editSplit.addWidget(save_dont)
 
         editSplit.addStretch(1)
 
@@ -98,7 +109,18 @@ class EditStack(QWidget):
 
     #save changes to database
     def save(self):
+        #TODO: save to datbase
         self.unsavedChanges = False
+
+    def reject(self):
+        #TODO: reload data from database
+        self.unsavedChanges = False
+
+    #sets the unsavedChanges flag
+    #a method is needed because assignment isn't allowed inside of lambda
+    #this method is called whenever the textboxes are modified
+    def makeChanges(self):
+        self.unsavedChanges = True
 
     #the MainMenu needs to be opened on close
     #edits need to be checked to unsure nothing is unsaved


### PR DESCRIPTION
- Front and back text fields
- Save and discard buttons
- Keeps tracks of when the text fields are modified

This code only creates the overall structure for adding text.  It needs to be integrated into the database once those changes are made.  It should be as easy as updating the row for the card in the database and loading the data from the database.

![image](https://user-images.githubusercontent.com/6538457/37687400-e1c04be4-2c71-11e8-91a4-e9b06d7644ea.png)

On clicking study after modifying a text box

![image](https://user-images.githubusercontent.com/6538457/37687433-fd2a1d9c-2c71-11e8-97d3-8dcfd05b1544.png)
